### PR TITLE
Be clear about implementation commitments + opposition

### DIFF
--- a/charter/draft-charter-2021.html
+++ b/charter/draft-charter-2021.html
@@ -219,6 +219,12 @@
             Recommendation</a>.
           </p>
           <p>
+            New specification features for should be expected to be supported
+            by at least two implementations, which may be judged by factors
+            including existing implementations, expressions of interest, and
+            lack of opposition.
+          </p>
+          <p>
             Where there are implications for implementors, developers, or
             users, in the areas of accessibility, internationalization,
             privacy, and security, each specification must have a section that


### PR DESCRIPTION
The [WebAppsSec charter](https://github.com/w3c/webappsec/pull/581/) has this nice addition, which I think we should also have around having two implementation commitments and no opposition. 

@LJWatson, wdyt? 
