### PR TITLE
add webidl as a possible deliverable

### DIFF
--- a/charter/draft-charter-2021.html
+++ b/charter/draft-charter-2021.html
@@ -210,26 +210,27 @@
             "https://www.w3.org/Consortium/Process/#implementation-experience">at
             least two independent implementations</a> in wide use.
           </p>
+
+          <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+
+          <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+
           <p>
             Each specification must have an accompanying test suite, which is
             ideally developed in parallel to the specification. The test suite
             will be used to produce an implementation report before the
             specification transitions to <a href=
-            "https://www.w3.org/2018/Process-20180201/#rec-pr">Proposed
+            "https://www.w3.org/2020/Process-20200915/#rec-pr">Proposed
             Recommendation</a>.
           </p>
           <p>
-            New specification features for should be expected to be supported
+            New specification features should be supported
             by at least two implementations, which may be judged by factors
             including existing implementations, expressions of interest, and
             lack of opposition.
           </p>
           <p>
-            Where there are implications for implementors, developers, or
-            users, in the areas of accessibility, internationalization,
-            privacy, and security, each specification must have a section that
-            describes relevant benefits, limitations, and best practice
-            solutions for that particular area.
+            Where there are implications for user experience,  each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations..
           </p>
         </section>
       </section>
@@ -403,6 +404,28 @@
               </td>
             </tr>
           </table>
+          <p>
+            Depending on the <a href=
+            "https://www.w3.org/2020/Process-20200915/#Consensus">Consensus</a> of the Working Group members, the Group may bring the following WHATWG Review Drafts from W3C Candidate Recommendation to Proposed Recommendation:
+          </p>
+          <table>
+            <tr>
+              <th>
+                Specification
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://heycam.github.io/webidl/">Web IDL</a>
+              </td>
+              <td>
+                This document defines an interface definition language, Web IDL, that can be used to describe interfaces that are intended to be implemented in web browsers. Web IDL is an IDL variant with a number of features that allow the behavior of common script objects in the web platform to be specified more readily. How interfaces described with Web IDL correspond to constructs within ECMAScript execution environments is also detailed in this document. It is expected that this document acts as a guide to implementors of already-published specifications, and that newly published specifications reference this document to ensure conforming implementations of interfaces are interoperable.
+              </td>
+            </tr>
+          </table>
         </section>
         <section id="wicgspecs">
           <h3>
@@ -548,15 +571,6 @@
           <dd>
             For architectural horizontal review, and to collaborate on
             architecture related topics.
-          </dd>
-          <dt>
-            <a href=
-            "https://www.w3.org/Consortium/activities#Web_Security_Interest_Group">
-            Web Security Interest Group</a>
-          </dt>
-          <dd>
-            For security horizontal review, and to collaborate on security
-            related topics.
           </dd>
         </dl>
         <p>

--- a/charter/draft-charter-2021.html
+++ b/charter/draft-charter-2021.html
@@ -861,7 +861,9 @@
                     Stopped Working on the HTML Accessibility API Mappings (AAM) spec;</li>
                     <li>
                     Remove Clipboard API and Events, ContentEditable, Selection API, and Input Events from the Deliverables.</li>
-                  </ul
+                    <li>
+                    Add WebIDL to the charter as a possible Deliverable.</li>
+                  </ul>
                 </td>
               </tr><!--
               <tr>

--- a/charter/draft-charter-2021.html
+++ b/charter/draft-charter-2021.html
@@ -210,27 +210,34 @@
             "https://www.w3.org/Consortium/Process/#implementation-experience">at
             least two independent implementations</a> in wide use.
           </p>
-
-          <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-
-          <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
-
+          <p>
+            Each specification should contain separate sections detailing all
+            known security and privacy implications for implementers, Web
+            authors, and end users.
+          </p>
+          <p>
+            There should be testing plans for each specification, starting from
+            the earliest drafts.
+          </p>
           <p>
             Each specification must have an accompanying test suite, which is
             ideally developed in parallel to the specification. The test suite
             will be used to produce an implementation report before the
             specification transitions to <a href=
-            "https://www.w3.org/2020/Process-20200915/#rec-pr">Proposed
+            "https://www.w3.org/Consortium/Process/#rec-pr">Proposed
             Recommendation</a>.
           </p>
           <p>
-            New specification features should be supported
-            by at least two implementations, which may be judged by factors
-            including existing implementations, expressions of interest, and
-            lack of opposition.
+            New specification features should be supported by at least two
+            implementations, which may be judged by factors including existing
+            implementations, expressions of interest, and lack of opposition.
           </p>
           <p>
-            Where there are implications for user experience,  each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations..
+            Where there are implications for user experience, each
+            specification should contain a section on accessibility that
+            describes the benefits and impacts, including ways specification
+            features can be used to address them, and recommendations for
+            maximising accessibility in implementations..
           </p>
         </section>
       </section>
@@ -406,7 +413,13 @@
           </table>
           <p>
             Depending on the <a href=
-            "https://www.w3.org/2020/Process-20200915/#Consensus">Consensus</a> of the Working Group members, the Group may bring the following WHATWG Review Drafts from W3C Candidate Recommendation to Proposed Recommendation:
+            "https://www.w3.org/Consortium/Process/#Consensus">Consensus</a> of
+            the Working Group members, the Group may bring the following WHATWG
+            Review Drafts from W3C Candidate Recommendation to Proposed
+            Recommendation, in accordance with the <a href=
+            "https://www.w3.org/2021/03/WHATWG-W3C-MOU.html">WHATWG-W3C
+            Memorandum of Understanding</a>: 
+            <!-- @@update with latest MOU link once available -->
           </p>
           <table>
             <tr>
@@ -422,7 +435,18 @@
                 <a href="https://heycam.github.io/webidl/">Web IDL</a>
               </td>
               <td>
-                This document defines an interface definition language, Web IDL, that can be used to describe interfaces that are intended to be implemented in web browsers. Web IDL is an IDL variant with a number of features that allow the behavior of common script objects in the web platform to be specified more readily. How interfaces described with Web IDL correspond to constructs within ECMAScript execution environments is also detailed in this document. It is expected that this document acts as a guide to implementors of already-published specifications, and that newly published specifications reference this document to ensure conforming implementations of interfaces are interoperable.
+                This document defines an interface definition language, Web
+                IDL, that can be used to describe interfaces that are intended
+                to be implemented in web browsers. Web IDL is an IDL variant
+                with a number of features that allow the behavior of common
+                script objects in the web platform to be specified more
+                readily. How interfaces described with Web IDL correspond to
+                constructs within ECMAScript execution environments is also
+                detailed in this document. It is expected that this document
+                acts as a guide to implementors of already-published
+                specifications, and that newly published specifications
+                reference this document to ensure conforming implementations of
+                interfaces are interoperable.
               </td>
             </tr>
           </table>
@@ -519,14 +543,24 @@
         <h2>
           Coordination
         </h2>
-        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
-          accessibility, internationalization, performance, privacy, and security with the relevant Working and
-          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
-          Invitation for review must be issued during each major standards-track document transition, including
-          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
-          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
-          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+        <p>
+          For all specifications, this Working Group will seek <a href=
+          "https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">
+          horizontal review</a> for accessibility, internationalization,
+          performance, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/"
+          title="Technical Architecture Group">TAG</a>. Invitation for review
+          must be issued during each major standards-track document transition,
+          including <a href="https://www.w3.org/Consortium/Process/#RecsWD"
+          title="First Public Working Draft">FPWD</a>. The Working Group is
+          encouraged to engage collaboratively with the horizontal review
+          groups throughout development of each specification. The Working
+          Group is advised to seek a review at least 3 months before first
+          entering <a href="https://www.w3.org/Consortium/Process/#RecsCR"
+          title="Candidate Recommendation">CR</a> and is encouraged to
+          proactively notify the horizontal review groups when major changes
+          occur in a specification following a review.
+        </p>
         <p>
           For all specifications, technical coordination with the following
           Groups will be made, per the <a href=
@@ -765,8 +799,9 @@
         </p>
         <p>
           For more information about disclosure obligations for this group,
-          please see the <a href="https://www.w3.org/2004/01/pp-impl/114929/status">W3C
-          Patent Policy Implementation</a>.
+          please see the <a href=
+          "https://www.w3.org/2004/01/pp-impl/114929/status">W3C Patent Policy
+          Implementation</a>.
         </p>
       </section>
       <section id="licensing">
@@ -819,7 +854,9 @@
               </tr>
               <tr>
                 <th>
-                  <a href="https://www.w3.org/2019/05/webapps-charter.html">Initial Charter</a>
+                  <a href=
+                  "https://www.w3.org/2019/05/webapps-charter.html">Initial
+                  Charter</a>
                 </th>
                 <td>
                   14 May 2019
@@ -833,7 +870,8 @@
               </tr>
               <tr>
                 <th>
-                  <a href="https://www.w3.org/2020/12/webapps-wg-charter.html">Rechartered</a>
+                  <a href=
+                  "https://www.w3.org/2020/12/webapps-wg-charter.html">Rechartered</a>
                 </th>
                 <td>
                   15 December 2020
@@ -857,12 +895,14 @@
                 </td>
                 <td>
                   <ul>
-                    <li>
-                    Stopped Working on the HTML Accessibility API Mappings (AAM) spec;</li>
-                    <li>
-                    Remove Clipboard API and Events, ContentEditable, Selection API, and Input Events from the Deliverables.</li>
-                    <li>
-                    Add WebIDL to the charter as a possible Deliverable.</li>
+                    <li>Stopped Working on the HTML Accessibility API Mappings
+                    (AAM) spec;
+                    </li>
+                    <li>Remove Clipboard API and Events, ContentEditable,
+                    Selection API, and Input Events from the Deliverables.
+                    </li>
+                    <li>Add WebIDL to the charter as a possible Deliverable.
+                    </li>
                   </ul>
                 </td>
               </tr><!--

--- a/charter/draft-charter-2021.html
+++ b/charter/draft-charter-2021.html
@@ -519,20 +519,14 @@
         <h2>
           Coordination
         </h2>
-        <p>
-          For all specifications, this Working Group will seek <a href=
-          "https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal
-          review</a> for accessibility, internationalization, performance,
-          privacy, and security with the relevant Working and Interest Groups,
-          and with the <a href="https://www.w3.org/2001/tag/" title=
-          "Technical Architecture Group">TAG</a>. Invitation for review must be
-          issued during each major standards-track document transition,
-          including <a href="https://www.w3.org/Consortium/Process/#RecsWD"
-          title="First Public Working Draft">FPWD</a> and at least 3 months
-          before <a href="https://www.w3.org/Consortium/Process/#RecsCR" title=
-          "Candidate Recommendation">CR</a>, and should be issued when major
-          changes occur in a specification following a review.
-        </p>
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+          accessibility, internationalization, performance, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track document transition, including
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
         <p>
           For all specifications, technical coordination with the following
           Groups will be made, per the <a href=
@@ -578,15 +572,6 @@
           "https://www.w3.org/WAI/ARIA/">Accessible Rich Internet Applications
           (ARIA) Working Group</a> to coordinate on the ARIA attributes on HTML
           elements, and their mappings to platform accessibility APIs.
-        </p>
-        <p>
-          Invitations for review will be issued for each major transition of a
-          specification, including <a href=
-          "https://www.w3.org/Consortium/Process/#RecsWD">First Public Working
-          Draft</a>, and at least 3 months before <a href=
-          "https://www.w3.org/Consortium/Process/#RecsCR">Candidate
-          Recommendation</a>, and should be issued when major changes occur in
-          a specification.
         </p>
         <div id="w3c-coordination">
           <h3>


### PR DESCRIPTION
To address comments from #49 and [strategy#269](https://github.com/w3c/strategy/issues/269#issuecomment-854072755).

- Add WebIDL to the Deliverables section;
- Remove the WebSec IG from Coordination;
- Switch to the latest charter template for the  Success Criteria section and the Coordination section;
