### PR TITLE
Cite /TR URIs for published TRs

### DIFF
--- a/charter/draft-charter-2021.html
+++ b/charter/draft-charter-2021.html
@@ -312,7 +312,7 @@
               <td>
                 An API for a database of records holding simple values and
                 hierarchical objects. The <a href=
-                "https://w3c.github.io/IndexedDB/">third edition</a> adds new
+                "https://www.w3.org/TR/IndexedDB/">third edition</a> adds new
                 capabilities and improves developer ergonomics by using
                 promises.
               </td>
@@ -1065,7 +1065,7 @@
             Estimated Completion: 2 year
           </dd>
           <dt id="1321" class='spec'>
-            <a href='https://w3c.github.io/IndexedDB/' rel='versionof'>Indexed
+            <a href='https://www.w3.org/TR/IndexedDB/' rel='versionof'>Indexed
             Database API 3.0</a><br>
             Status: <a href='https://w3c.github.io/IndexedDB/'>Editor's
             Draft</a>


### PR DESCRIPTION
For published Rec-track documents use the /TR URI under the primary document title, while maintaining the Editor's Draft citation in the document status sentence.