### PR TITLE
PING comments on the 2023 charter

### DIFF
--- a/charter/draft-charter-2023.html
+++ b/charter/draft-charter-2023.html
@@ -174,7 +174,7 @@
           </li>
           <li>Obtaining and providing the location of the hosting device.
           </li>
-          <li>Reacting changes in motion and orientation of the hosting device.
+          <li>Reacting to changes in motion and orientation of the hosting device.
           </li>
         </ul>
         <p>

--- a/charter/draft-charter-2023.html
+++ b/charter/draft-charter-2023.html
@@ -172,9 +172,9 @@
           </li>
           <li>Preventing the screen from turning off under certain conditions.
           </li>
-          <li>Obtaining and monitoring the location of the hosting device.
+          <li>Obtaining and providing the location of the hosting device.
           </li>
-          <li>Monitoring changes in motion and orientation of the hosting device.
+          <li>Reacting changes in motion and orientation of the hosting device.
           </li>
         </ul>
         <p>
@@ -598,13 +598,7 @@ test suite of every feature defined in the specification.</p>
     </p>
 
     <!-- Horizontal review -->
-    <p>Each specification should contain sections detailing 
-    security and privacy implications for implementers, 
-    Web authors, and end users, 
-    as well as recommendations for mitigations.
-    There should be a clear description of the residual risk 
-    to the user or operator of that protocol 
-    after threat mitigation has been deployed.</p>
+    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations.</p>
 
@@ -639,6 +633,14 @@ test suite of every feature defined in the specification.</p>
             <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C
             Process</a>.
           </p>
+          <dl>
+          <dt>
+            <a href="https://www.w3.org/groups/wg/das">Devices and Sensors Working Group</a>
+          </dt>
+          <dd>
+            The Web Application Working Group will coordinate with the Devices and Sensors Working Group regarding the <a href="#11343">Contact Picker API</a>, the <a href="#11508">Screen Wake Lock API</a>, the <a href="#11583">DeviceOrientation Event Specification</a> and the <a href="#10342">Geolocation API</a>.
+          </dd>
+        </dl>
         </section>
 
         <section>
@@ -755,7 +757,7 @@ test suite of every feature defined in the specification.</p>
           If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>
         <p>
-          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs.
         </p>
         <p>
           This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
@@ -765,8 +767,6 @@ test suite of every feature defined in the specification.</p>
 
 
       <section id="patentpolicy">
-      <p>Patent Policy</p>
-
         <h2>
           Patent Policy
         </h2>
@@ -1000,7 +1000,7 @@ test suite of every feature defined in the specification.</p>
 
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/contact-picker/">Working Draft</a></p>
 
-              <p class="milestone"><b>Expected completion:</b> CR - Q4 2023; REC - Q4 2024</p>
+              <p class="milestone"><b>Expected completion:</b> CR - Q4 2024</p>
 
             <p><b>Adopted Draft:</b> Contact Picker API9, <a href="https://www.w3.org/TR/2023/WD-web-locks-20230105/">https://www.w3.org/TR/2023/WD-web-locks-20230105/</a>, 5 January 2023</p>
 


### PR DESCRIPTION
This pull is to take in the [advice from the PING](https://github.com/w3c/strategy/issues/383#issuecomment-1743407115) on the proposed charter:
* use more accurate words for the scope;
* add the DAS WG to the Coordination section;

Also, to align with the latest W3C charter template,
* remove _the Director_ from the Decision Policy section;
* update the language of the Success Criteria section about horizontal  review.

Special thanks to @npdoty and others in the PING.