### PR TITLE
update the WICG session

### DIFF
--- a/charter/draft-charter-2025.html
+++ b/charter/draft-charter-2025.html
@@ -449,11 +449,13 @@
             </tr>
             <tr>
               <td>
-                <a href="https://wicg.github.io/cookie-store/">Cookie Store</a>
+                <a href="https://wicg.github.io/entries-api/">File and Directory Entries API</a>
               </td>
               <td>
-                An asynchronous Javascript cookies API for documents and
-                workers.
+                This specification documents web browser support for file and 
+                directory upload by drag-and-drop operations. It introduces types
+                representing directories with methods for asynchronous traversal,
+                and extends HTMLInputElement and DataTransferItem.
               </td>
             </tr>
             <tr>
@@ -491,6 +493,14 @@
                 negotiation when necessary, while avoiding the historical
                 baggage and passive fingerprinting surface exposed by the
                 venerable <code>User-Agent</code> HTTP header.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://wicg.github.io/background-fetch/">Background Fetch</a>
+              </td>
+              <td>
+                An API to handle large uploads/downloads in the background with user visibility.
               </td>
             </tr>
           </table>


### PR DESCRIPTION
Add [File and Directory Entries API](https://wicg.github.io/entries-api/) to the WICG session;

Note: We are keeping [Haptics](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/HapticsDevice/explainer.md) for Gamepad.

TBD:

- Remove Cookie Store API as the latest proposal is to [transfer it to WHATWG](https://github.com/whatwg/sg/issues/252).
- Remove [User-Agent Client Hints](https://wicg.github.io/ua-client-hints/) as it may be more appropriate under the WebPerf WG?
- Add [Background Fetch](https://wicg.github.io/background-fetch/), since we're taking over development of the Service Workers spec?

Any suggestions?

